### PR TITLE
Add public getter `is_active`

### DIFF
--- a/src/Kaleidoscope/Syster.cpp
+++ b/src/Kaleidoscope/Syster.cpp
@@ -46,6 +46,10 @@ void Syster::reset(void) {
   is_active_ = false;
 }
 
+bool Syster::is_active(void) {
+  return is_active_;
+}
+
 // --- hooks ---
 Key Syster::eventHandlerHook(Key mapped_key, byte row, byte col, uint8_t key_state) {
   if (!is_active_) {

--- a/src/Kaleidoscope/Syster.h
+++ b/src/Kaleidoscope/Syster.h
@@ -40,6 +40,8 @@ class Syster : public KaleidoscopePlugin {
   void begin(void) final;
   static void reset(void);
 
+  bool is_active(void);
+
  private:
   static char symbol_[SYSTER_MAX_SYMBOL_LENGTH + 1];
   static uint8_t symbol_pos_;


### PR DESCRIPTION
This is helpful within a loop hook to keep a single LED a different color while Syster is active and the LED mode is animated.